### PR TITLE
Add score events and listeners

### DIFF
--- a/app/Events/ScoreCreated.php
+++ b/app/Events/ScoreCreated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Score;
+
+class ScoreCreated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public $score;
+
+    public function __construct(Score $score)
+    {
+        $this->score = $score;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Events/ScoreUpdated.php
+++ b/app/Events/ScoreUpdated.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use App\Models\Score;
+
+class ScoreUpdated
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public $score;
+
+    public function __construct(Score $score)
+    {
+        $this->score = $score;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel-name'),
+        ];
+    }
+}

--- a/app/Listeners/SendScoreNotification.php
+++ b/app/Listeners/SendScoreNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ScoreCreated;
+use App\Events\ScoreUpdated;
+use App\Models\Notification;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class SendScoreNotification
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle($event)
+    {
+        $users = User::where('isAdmin', 1)->get();
+        $scoreUser = User::find($event->score->user_id);
+
+        foreach ($users as $user) {
+            $notification = [
+                'user_id' => $user->id,
+                'message' => "{$scoreUser->username} has added a new time to {$event->score->race_name}: {$event->score->score}",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+
+            Notification::insert($notification);
+        }
+    }
+}

--- a/app/Models/Score.php
+++ b/app/Models/Score.php
@@ -12,4 +12,9 @@ class Score extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    protected $dispatchesEvents = [
+        'created' => \App\Events\ScoreCreated::class,
+        'updated' => \App\Events\ScoreUpdated::class,
+    ];
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,6 +18,12 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
+        \App\Events\ScoreCreated::class => [
+            \App\Listeners\SendScoreNotification::class,
+        ],
+        \App\Events\ScoreUpdated::class => [
+            \App\Listeners\SendScoreNotification::class,
+        ],
     ];
 
     /**


### PR DESCRIPTION
This pull request adds two new events and listeners: ScoreCreated and ScoreUpdated. These events are triggered when a new score is created or when an existing score is updated. The listeners send notifications to all admin users when a score is created or updated.